### PR TITLE
Fix class name error in insert tag hook

### DIFF
--- a/src/Classes/Hooks/con4gisInsertTags.php
+++ b/src/Classes/Hooks/con4gisInsertTags.php
@@ -19,7 +19,7 @@ use Contao\System;
  * Class con4gisInsertTag
  * @package con4gis\CoreBundle\Classes\Hooks
  */
-class con4gisInsertTags extends \System
+class con4gisInsertTags extends System
 {
     /**
      * Instanz des Symfony EventDispatchers


### PR DESCRIPTION
This PR fixes the following error:

```
Uncaught PHP Exception Error: "Class "System" not found" at con4gisInsertTags.php line 22
```