### PR TITLE
Fix a warning in `C4gBrickCallback` on new installation

### DIFF
--- a/src/Classes/Callback/C4gBrickCallback.php
+++ b/src/Classes/Callback/C4gBrickCallback.php
@@ -419,7 +419,11 @@ class C4gBrickCallback extends Backend
     public function globalSettings($href, $label, $title, $class, $attributes)
     {
         $rt = Input::get('rt');
-        $result = Database::getInstance()->execute("SELECT id FROM tl_c4g_settings LIMIT 1")->fetchAssoc();
+
+        if (!$result = Database::getInstance()->execute("SELECT id FROM tl_c4g_settings LIMIT 1")->fetchAssoc()) {
+            return '';
+        }
+
         $href = System::getContainer()->get('router')->generate('contao_backend') .'?do=c4g_settings&id="' . $result['id'].'"&rt='.$rt.'&key=openSettings';
         return $this->User->hasAccess('c4g_settings', 'modules') ? '<a href="' . $href . '" class="' . $class . '" title="' . StringUtil::specialchars($title) . '"' . $attributes . '>' . $label . '</a> ' : Image::getHtml(preg_replace('/\.svg$/i', '_.svg', $icon)) . ' ';
     }


### PR DESCRIPTION
Fixes the following warning:

```
ErrorException:
Warning: Trying to access array offset on false

  at vendor\con4gis\core\src\Classes\Callback\C4gBrickCallback.php:423
```